### PR TITLE
Refactor: Remove modules

### DIFF
--- a/js/complex.js
+++ b/js/complex.js
@@ -78,5 +78,3 @@ Complex.exp = function(c, e) {
 Complex.abs = function(c) {
     return (c.re ** 2 + c.im ** 2) ** 0.5;
 };
-
-export default Complex;

--- a/js/fractal.js
+++ b/js/fractal.js
@@ -1,5 +1,3 @@
-import Complex from "./complex.js";
-
 /******************************
 FRACTAL PROTOTYPES: THEORETICAL MATHEMATICAL SETS IN THE COMPLEX PLANE:
 ******************************/
@@ -155,10 +153,4 @@ var getJuliaEquivalent = function(fractalType) {
         "BurningShip": "BurningShipJulia",
         "Multiship": "MultishipJulia"
     }[fractalType];
-};
-
-export {
-    Mandelbrot, Julia, Multibrot, Multijulia,
-    BurningShip, BurningShipJulia, Multiship, MultishipJulia,
-    requiresExponent, requiresJuliaConstant, getJuliaEquivalent
 };

--- a/js/frame.js
+++ b/js/frame.js
@@ -1,5 +1,3 @@
-import Complex from "./complex.js";
-
 /******************************
 FRAME PROTOTYPE: REGION ON THE COMPLEX PLANE
 ******************************/
@@ -46,5 +44,3 @@ Frame.prototype.fitToCanvas = function(w, h) {
         );
     }
 };
-
-export default Frame;

--- a/js/image.js
+++ b/js/image.js
@@ -1,6 +1,3 @@
-import {hsl, rgb, scale} from "./utils.js";
-import Complex from "./complex.js";
-
 /******************************
 IMAGE PROTOTYPE: RENDERING OF A FRACTAL WITH ITERATIONS, FRAME, AND CANVAS SIZE
 ******************************/
@@ -118,5 +115,3 @@ Image.prototype.copy = function() {
         this.canvasCtx
     );
 };
-
-export default Image;

--- a/js/main.js
+++ b/js/main.js
@@ -1,14 +1,3 @@
-import {rgb, hsl, scale} from "./modules/utils.js";
-import Complex from "./modules/complex.js";
-import {
-    Mandelbrot, Julia, Multibrot, Multijulia,
-    BurningShip, BurningShipJulia, Multiship, MultishipJulia,
-    requiresExponent, requiresJuliaConstant, getJuliaEquivalent
-} from "./modules/fractal.js";
-import Frame from "./modules/frame.js";
-import Image from "./modules/image.js";
-
-
 var canvas = document.getElementById("canvas");
 var canvasCtx = canvas.getContext("2d");
 var controlsCanvas = document.getElementById("controls-canvas");

--- a/js/utils.js
+++ b/js/utils.js
@@ -13,5 +13,3 @@ var rgb = function(r, g, b) {
 var scale = function(n, minFrom, maxFrom, minTo, maxTo) {
     return ((n / (maxFrom - minFrom)) * (maxTo - minTo)) + minTo;
 };
-
-export {hsl, rgb, scale};

--- a/main.html
+++ b/main.html
@@ -94,11 +94,11 @@
                 <input type="button" id="redraw" value="Redraw"/>
             </div>
         </div>
-        <script type="module" src="./js/modules/utils.js"></script>
-        <script type="module" src="./js/modules/complex.js"></script>
-        <script type="module" src="./js/modules/fractal.js"></script>
-        <script type="module" src="./js/modules/frame.js"></script>
-        <script type="module" src="./js/modules/image.js"></script>
-        <script type="module" src="./js/main.js"></script>
+        <script src="./js/utils.js"></script>
+        <script src="./js/complex.js"></script>
+        <script src="./js/fractal.js"></script>
+        <script src="./js/frame.js"></script>
+        <script src="./js/image.js"></script>
+        <script src="./js/main.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Remove modules to more easily add future features, such as the `Worker` API, which currently has limited browser support with modules.