### PR TITLE
Add asynchronous rendering

### DIFF
--- a/js/fractal.js
+++ b/js/fractal.js
@@ -1,10 +1,16 @@
 /******************************
-FRACTAL PROTOTYPES: THEORETICAL MATHEMATICAL SETS IN THE COMPLEX PLANE:
+FRACTALS: THEORETICAL MATHEMATICAL SETS IN THE COMPLEX PLANE:
 ******************************/
 
-var Mandelbrot = function() {};
+var Fractal = function(type, params) {
+    this.type = type;
+    this.params = params ? params : {};
+};
 
-Mandelbrot.prototype.iterate = function(c, iterations, escapeRadius) {
+// Object with iteration functions for each type of fractal
+var Iterate = {};
+
+Iterate.Mandelbrot = function(params, c, iterations, escapeRadius) {
     let z = Complex(0, 0);
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
@@ -14,60 +20,37 @@ Mandelbrot.prototype.iterate = function(c, iterations, escapeRadius) {
     return n;
 };
 
-
-
-var Julia = function(c) {
-    this.c = c;
-};
-
-Julia.prototype.iterate = function(_z, iterations, escapeRadius) {
+Iterate.Julia = function(params, _z, iterations, escapeRadius) {
     let z = _z;
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
-        z = Complex.add(Complex.mul(z, z), this.c);
+        z = Complex.add(Complex.mul(z, z), params.c);
         n++;
     }
     return n;
 };
 
-
-
-var Multibrot = function(e) {
-    this.e = e;
-};
-
-Multibrot.prototype.iterate = function(c, iterations, escapeRadius) {
+Iterate.Multibrot = function(params, c, iterations, escapeRadius) {
     let z = Complex(0, 0);
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
-        z = Complex.add(Complex.exp(z, this.e), c);
+        z = Complex.add(Complex.exp(z, params.e), c);
         n++;
     }
     return n;
 };
 
-
-
-var Multijulia = function(e, c) {
-    this.e = e;
-    this.c = c;
-}; 
-
-Multijulia.prototype.iterate = function(_z, iterations, escapeRadius) {
+Iterate.Multijulia = function(params, _z, iterations, escapeRadius) {
     let z = _z;
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
-        z = Complex.add(Complex.exp(z, this.e), this.c);
+        z = Complex.add(Complex.exp(z, params.e), params.c);
         n++;
     }
     return n;
 };
 
-
-
-var BurningShip = function() {};
-
-BurningShip.prototype.iterate = function(c, iterations, escapeRadius) {
+Iterate.BurningShip = function(params, c, iterations, escapeRadius) {
     let z = Complex(0, 0);
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
@@ -77,49 +60,31 @@ BurningShip.prototype.iterate = function(c, iterations, escapeRadius) {
     return n;
 };
 
-
-
-var BurningShipJulia = function(c) {
-    this.c = c;
-};
-
-BurningShipJulia.prototype.iterate = function(_z, iterations, escapeRadius) {
+Iterate.BurningShipJulia = function(params, _z, iterations, escapeRadius) {
     let z = _z;
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
-        z = Complex.add(Complex.exp(Complex(Math.abs(z.re), Math.abs(z.im)), 2), this.c);
+        z = Complex.add(Complex.exp(Complex(Math.abs(z.re), Math.abs(z.im)), 2), params.c);
         n++;
     }
     return n;
 };
 
-
-
-var Multiship = function(e) {
-    this.e = e;
-};
-Multiship.prototype.iterate = function(c, iterations, escapeRadius) {
+Iterate.Multiship = function(params, c, iterations, escapeRadius) {
     let z = Complex(0, 0);
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
-        z = Complex.add(Complex.exp(Complex(Math.abs(z.re), Math.abs(z.im)), this.e), c);
+        z = Complex.add(Complex.exp(Complex(Math.abs(z.re), Math.abs(z.im)), params.e), c);
         n++;
     }
     return n;
 };
 
-
-
-var MultishipJulia = function(e, c) {
-    this.e = e;
-    this.c = c;
-};
-
-MultishipJulia.prototype.iterate = function(_z, iterations, escapeRadius) {
+Iterate.MultishipJulia = function(params, _z, iterations, escapeRadius) {
     let z = _z;
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
-        z = Complex.add(Complex.exp(Complex(Math.abs(z.re), Math.abs(z.im)), this.e), this.c);
+        z = Complex.add(Complex.exp(Complex(Math.abs(z.re), Math.abs(z.im)), params.e), params.c);
         n++;
     }
     return n;

--- a/js/fractal.js
+++ b/js/fractal.js
@@ -8,9 +8,9 @@ var Fractal = function(type, params) {
 };
 
 // Object with iteration functions for each type of fractal
-var Iterate = {};
+var iterateFractal = {};
 
-Iterate.Mandelbrot = function(params, c, iterations, escapeRadius) {
+iterateFractal.Mandelbrot = function(params, c, iterations, escapeRadius) {
     let z = Complex(0, 0);
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
@@ -20,7 +20,7 @@ Iterate.Mandelbrot = function(params, c, iterations, escapeRadius) {
     return n;
 };
 
-Iterate.Julia = function(params, _z, iterations, escapeRadius) {
+iterateFractal.Julia = function(params, _z, iterations, escapeRadius) {
     let z = _z;
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
@@ -30,7 +30,7 @@ Iterate.Julia = function(params, _z, iterations, escapeRadius) {
     return n;
 };
 
-Iterate.Multibrot = function(params, c, iterations, escapeRadius) {
+iterateFractal.Multibrot = function(params, c, iterations, escapeRadius) {
     let z = Complex(0, 0);
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
@@ -40,7 +40,7 @@ Iterate.Multibrot = function(params, c, iterations, escapeRadius) {
     return n;
 };
 
-Iterate.Multijulia = function(params, _z, iterations, escapeRadius) {
+iterateFractal.Multijulia = function(params, _z, iterations, escapeRadius) {
     let z = _z;
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
@@ -50,7 +50,7 @@ Iterate.Multijulia = function(params, _z, iterations, escapeRadius) {
     return n;
 };
 
-Iterate.BurningShip = function(params, c, iterations, escapeRadius) {
+iterateFractal.BurningShip = function(params, c, iterations, escapeRadius) {
     let z = Complex(0, 0);
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
@@ -60,7 +60,7 @@ Iterate.BurningShip = function(params, c, iterations, escapeRadius) {
     return n;
 };
 
-Iterate.BurningShipJulia = function(params, _z, iterations, escapeRadius) {
+iterateFractal.BurningShipJulia = function(params, _z, iterations, escapeRadius) {
     let z = _z;
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
@@ -70,7 +70,7 @@ Iterate.BurningShipJulia = function(params, _z, iterations, escapeRadius) {
     return n;
 };
 
-Iterate.Multiship = function(params, c, iterations, escapeRadius) {
+iterateFractal.Multiship = function(params, c, iterations, escapeRadius) {
     let z = Complex(0, 0);
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {
@@ -80,7 +80,7 @@ Iterate.Multiship = function(params, c, iterations, escapeRadius) {
     return n;
 };
 
-Iterate.MultishipJulia = function(params, _z, iterations, escapeRadius) {
+iterateFractal.MultishipJulia = function(params, _z, iterations, escapeRadius) {
     let z = _z;
     let n = 0;
     while(Complex.abs(z) <= escapeRadius && n < iterations) {

--- a/js/image.js
+++ b/js/image.js
@@ -29,12 +29,6 @@ var Image = function(fractal, iterations, escapeRadius, srcFrame, width, height,
 };
 
 
-// Return the fractal type as a string
-Image.prototype.getFractalType = function() {
-    return this.fractal.constructor.name;
-};
-
-
 // Fit drawing frame to canvas and
 // update dependent parameters
 Image.prototype.fitToCanvas = function(width, height) {
@@ -59,7 +53,8 @@ Image.prototype.drawLayer = function() {
     let currRe = this.frame.reMin;
     for(let currX = 0; currX < this.width; currX++) {
 
-        let val = this.fractal.iterate(
+        let val = Iterate[this.fractal.type](
+            this.fractal.params,
             Complex(currRe, this.currIm),
             this.iterations,
             this.escapeRadius

--- a/js/image.js
+++ b/js/image.js
@@ -53,7 +53,7 @@ Image.prototype.drawLayer = function() {
     let currRe = this.frame.reMin;
     for(let currX = 0; currX < this.width; currX++) {
 
-        let val = Iterate[this.fractal.type](
+        let val = iterateFractal[this.fractal.type](
             this.fractal.params,
             Complex(currRe, this.currIm),
             this.iterations,

--- a/js/image.js
+++ b/js/image.js
@@ -2,7 +2,7 @@
 IMAGE PROTOTYPE: RENDERING OF A FRACTAL WITH ITERATIONS, FRAME, AND CANVAS SIZE
 ******************************/
 
-var Image = function(fractal, iterations, escapeRadius, srcFrame, width, height, canvasCtx) {
+var Image = function(fractal, iterations, escapeRadius, srcFrame, width, height) {
     this.fractal = fractal;
     this.iterations = iterations;
     this.escapeRadius = escapeRadius;
@@ -12,8 +12,6 @@ var Image = function(fractal, iterations, escapeRadius, srcFrame, width, height,
 
     this.width = width;
     this.height = height;
-
-    this.canvasCtx = canvasCtx;
     
     // Distance between pixels on the complex plane
     this.complexIter = 
@@ -45,49 +43,6 @@ Image.prototype.fitToCanvas = function(width, height) {
 // Set the source frame
 Image.prototype.setFrame = function(srcFrame) {
     this.srcFrame = srcFrame;
-};
-
-
-// Draw one layer, moving down
-Image.prototype.drawLayer = function() {
-    let currRe = this.frame.reMin;
-    for(let currX = 0; currX < this.width; currX++) {
-
-        let val = iterateFractal[this.fractal.type](
-            this.fractal.params,
-            Complex(currRe, this.currIm),
-            this.iterations,
-            this.escapeRadius
-        );
-        
-        if(val == this.iterations) {
-            // Part of set, color black
-            this.canvasCtx.fillStyle = hsl(0, 0, 0);
-        }
-        else {
-            // Color scale: HSL (0-360, 100, 0-100)
-            this.canvasCtx.fillStyle = hsl(
-                scale(val, 0, this.iterations, 0, 360),
-                100,
-                scale(val, 0, this.iterations, 0, 100)
-            );
-        }
-        
-        this.canvasCtx.fillRect(currX, this.currY, 1, 1);
-        
-        currRe += this.complexIter;
-    };
-    
-    this.currY += 1;
-    this.currIm += this.complexIter;
-    
-    // Stop if at the bottom of the canvas
-    if(this.currY > this.height) {
-        this.drawing = false;
-    }
-
-    // Update render time
-    this.renderTime = new Date() - this.startTime;
 };
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -26,49 +26,49 @@ var defaultView = new Frame(Complex(0, 0), 4, 4);
 // Images
 var defaultImages = {
     Mandelbrot: new Image(
-        new Mandelbrot(),
+        new Fractal("Mandelbrot"),
         100, 2,
         new Frame(Complex(-0.5, 0), 4, 4),
         canvasWidth, canvasHeight, canvasCtx
     ),
     Julia: new Image(
-        new Julia(Complex(-0.8, 0.156)),
+        new Fractal("Julia", {c: Complex(-0.8, 0.156)}),
         100, 2,
         defaultView,
         canvasWidth, canvasHeight, canvasCtx
     ),
     Multibrot: new Image(
-        new Multibrot(3),
+        new Fractal("Multibrot", {e: 3}),
         100, 2,
         defaultView,
         canvasWidth, canvasHeight, canvasCtx
     ),
     Multijulia: new Image(
-        new Multijulia(3, Complex(-0.12, -0.8)),
+        new Fractal("Multijulia", {e: 3, c: Complex(-0.12, -0.8)}),
         100, 2,
         defaultView,
         canvasWidth, canvasHeight, canvasCtx
     ),
     BurningShip: new Image(
-        new BurningShip(),
+        new Fractal("BurningShip"),
         100, 2,
         new Frame(Complex(0, -0.5), 4, 4),
         canvasWidth, canvasHeight, canvasCtx
     ),
     BurningShipJulia: new Image(
-        new BurningShipJulia(Complex(-1.5, 0)),
+        new Fractal("BurningShipJulia", {c: Complex(-1.5, 0)}),
         100, 2,
         defaultView,
         canvasWidth, canvasHeight, canvasCtx
     ),
     Multiship: new Image(
-        new Multiship(3),
+        new Fractal("Multiship", {e: 3}),
         100, 2,
         defaultView,
         canvasWidth, canvasHeight, canvasCtx
     ),
     MultishipJulia: new Image(
-        new MultishipJulia(3, Complex(-1.326667, 0)),
+        new Fractal("MultishipJulia", {e: 3, c: Complex(-1.326667, 0)}),
         100, 2,
         defaultView,
         canvasWidth, canvasHeight, canvasCtx
@@ -140,10 +140,10 @@ var toolbar = {
     // For currently undefined variables
     init() {
         // Internal input variables
-        this.fractalType = this.lastFractalType = currImg.getFractalType();
-        this.exponent = this.lastExponent = currImg.fractal.e || null;
+        this.fractalType = this.lastFractalType = currImg.fractal.type;
+        this.exponent = this.lastExponent = currImg.fractal.params.e || null;
         this.juliaConstant = this.lastJuliaConstant =
-            currImg.fractal.c || Complex(null, null);
+            currImg.fractal.params.c || Complex(null, null);
         this.iterations = currImg.iterations;
         this.iterationIncrement = Number(this.elements.iterationIncrement.value);
         this.escapeRadius = Number(this.elements.escapeRadius.value);
@@ -443,8 +443,8 @@ var toolbar = {
         }
 
         // Check for new exponent
-        if(requiresExponent(currImg.getFractalType())) {
-            currImg.fractal.e = this.exponent;
+        if(requiresExponent(currImg.fractal.type)) {
+            currImg.fractal.params.e = this.exponent;
 
             // If exponent has changed, return to original frame
             // (i.e. don't stay zoomed in, same for Julia constant below)
@@ -455,8 +455,8 @@ var toolbar = {
         }
 
         // Check for new Julia constant
-        if(requiresJuliaConstant(currImg.getFractalType())) {
-            currImg.fractal.c = this.juliaConstant;
+        if(requiresJuliaConstant(currImg.fractal.type)) {
+            currImg.fractal.params.c = this.juliaConstant;
             if(!Complex.equals(this.juliaConstant, this.lastJuliaConstant)) {
                 currImg.setFrame(defaultView);
                 fractalChanged = true;
@@ -494,7 +494,7 @@ var toolbar = {
 
         // Manually set fractal type input and update
         // internals accordingly, a little dirty...
-        this.elements.fractalType.value = currImg.getFractalType();
+        this.elements.fractalType.value = currImg.fractal.type;
         this.updateInternalFractalType();
 
         let currFractal = currImg.fractal;
@@ -502,15 +502,15 @@ var toolbar = {
         this.lastFractalType = currFractal;
 
         // Sync Exponent
-        if(currFractal.e) {
-            this.elements.exponent.value = currFractal.e.toString();
-            this.exponent = this.lastExponent = currFractal.e;
+        if(currFractal.params.e) {
+            this.elements.exponent.value = currFractal.params.e.toString();
+            this.exponent = this.lastExponent = currFractal.params.e;
         }
 
         // Sync Julia constant
-        if(currFractal.c) {
-            this.elements.juliaConstant.value = Complex.toString(currImg.fractal.c);
-            this.juliaConstant = this.lastJuliaConstant = currFractal.c;
+        if(currFractal.params.c) {
+            this.elements.juliaConstant.value = Complex.toString(currImg.fractal.params.c);
+            this.juliaConstant = this.lastJuliaConstant = currFractal.params.c;
         }
 
         // Sync iterations
@@ -573,7 +573,7 @@ controlsCanvas.onmouseup = function() {
                 // Switch to Julia mode
 
                 // Confirm that Julia mode is applicable
-                if(!requiresJuliaConstant(currImg.getFractalType())) {
+                if(!requiresJuliaConstant(currImg.fractal.type)) {
                     currMode = "julia";
 
                     // Store current image for switching back
@@ -581,17 +581,17 @@ controlsCanvas.onmouseup = function() {
 
                     // Initialize new image based on Julia
                     // equivalent of previous fractal
-                    let newFractal = getJuliaEquivalent(currImg.getFractalType());
+                    let newFractal = getJuliaEquivalent(currImg.fractal.type);
                     currImg = defaultImages[newFractal].copy();
 
                     // New fractal requires a julia constant,
                     // but not necessarily an exponent
-                    currImg.fractal.c = storedImg.frame.toComplexCoords(
+                    currImg.fractal.params.c = storedImg.frame.toComplexCoords(
                         mouseX, mouseY,
                         canvasWidth, canvasHeight
                     );
                     if(requiresExponent(newFractal)) {
-                        currImg.fractal.e = storedImg.fractal.e;
+                        currImg.fractal.params.e = storedImg.fractal.params.e;
                     }
                 }
             }

--- a/js/main.js
+++ b/js/main.js
@@ -90,6 +90,7 @@ renderWorker.onmessage = function(event) {
     let data = event.data;
     if(data.type == "progress") {
         toolbar.displayRenderTime(data.renderTime);
+        toolbar.displayProgress(data.progress);
     }
     if(data.type == "done") {
         canvasCtx.putImageData(data.imgData, 0, 0);
@@ -139,6 +140,8 @@ var toolbar = {
 
         // Display
         renderTime: document.getElementById("render-time"),
+        progress: document.getElementById("progress"),
+        progressBar: document.getElementById("progress-bar"),
         mouseComplexCoords: document.getElementById("mouse-complex-coords"),
         zoom: document.getElementById("zoom"),
 
@@ -226,7 +229,14 @@ var toolbar = {
 
     // Render time
     displayRenderTime(time) {
-        this.elements.renderTime.innerHTML = time.toString();
+        this.elements.renderTime.innerHTML = time.toString() + " ms";
+    },
+
+
+    // Progress
+    displayProgress(progress) {
+        this.elements.progress.innerHTML = progress + "%";
+        this.elements.progressBar.value = progress;
     },
 
 

--- a/js/render.js
+++ b/js/render.js
@@ -1,0 +1,61 @@
+importScripts("./complex.js", "./fractal.js", "./utils.js");
+
+onmessage = function(event) {
+    let data = event.data;
+    if(data.type == "draw") {
+        let startTime = new Date();
+        let renderTime;
+
+        let img = data.img;
+        let iterate = iterateFractal[img.fractal.type];
+
+        let imgData = new ImageData(img.width, img.height);
+
+        let im = img.frame.imMin;
+        let i = 0;
+        for(let currY = 0; currY < img.height; currY++) {
+            let re = img.frame.reMin;
+            for(let currX = 0; currX < img.width; currX++) {
+                let val = iterate(
+                    img.fractal.params,
+                    Complex(re, im),
+                    img.iterations,
+                    img.escapeRadius
+                );
+
+                let bw;
+                if(val == img.iterations) {
+                    // Part of set, color black
+                    bw = 0;
+                }
+                else {
+                    // Color scale
+                    bw = scale(val, 0, img.iterations, 0, 255);
+                }
+
+                imgData.data[i] = bw;
+                imgData.data[i + 1] = bw;
+                imgData.data[i + 2] = bw;
+                imgData.data[i + 3] = 255;
+
+                re += img.complexIter;
+                i += 4;
+            }
+            im += img.complexIter;
+
+            // Update render time
+            renderTime = new Date() - startTime;
+
+            this.postMessage({
+                type: "progress",
+                progress: i,
+                renderTime: renderTime
+            });
+        }
+        this.postMessage({
+            type: "done",
+            imgData: imgData,
+            renderTime: renderTime
+        });
+    }
+};

--- a/js/render.js
+++ b/js/render.js
@@ -48,7 +48,7 @@ onmessage = function(event) {
 
             this.postMessage({
                 type: "progress",
-                progress: i,
+                progress: Math.round(i / 4 / (img.width * img.height) * 100),
                 renderTime: renderTime
             });
         }

--- a/main.html
+++ b/main.html
@@ -12,11 +12,19 @@
         </div>
         <br/>
         <div id="toolbar">
-            <div id="render-time-container">
-                Render time: <div id="render-time" class="inline"></div> ms
+            <div id="progress-toolbar">
+                <div id="progress-container">
+                    Progress: <div id="progress" class="inline"></div>
+                </div>
+                <div id="progress-bar-container">
+                    <progress id="progress-bar" max="100"></progress>
+                </div>
+                <div id="render-time-container">
+                    Render time: <div id="render-time" class="inline"></div>
+                </div>
             </div>
             <hr>
-            <div id="mouse-coords-container">
+            <div id="mouse-coords-toolbar">
                 Mouse coordinates: <div id="mouse-complex-coords" class="inline"></div>
             </div>
             <hr>


### PR DESCRIPTION
Rendering now takes place in a `Worker`. Before, the code used `setTimeout` with a delay of 0 to render layer by layer. This feature drastically decreases render times from 3400ms+ to ~70ms for the default Mandelbrot image.